### PR TITLE
Fixes unexpected behavior of (**

### DIFF
--- a/ocaml.configuration.json
+++ b/ocaml.configuration.json
@@ -4,7 +4,7 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": [ "string" ] },
-    { "open": "(**", "close": " *)", "notIn": [ "string" ] }
+    { "open": "(**", "close": " *", "notIn": [ "string" ] }
   ],
   "brackets": [
     [ "{", "}" ],


### PR DESCRIPTION
Adjusts for autocompleted parentheses, allowing for (** *) instead of (** *))  